### PR TITLE
avoiding nan

### DIFF
--- a/models/vn_layers.py
+++ b/models/vn_layers.py
@@ -117,7 +117,8 @@ class VNBatchNorm(nn.Module):
         '''
         x: point features of shape [B, N_feat, 3, N_samples, ...]
         '''
-        norm = torch.sqrt((x*x).sum(2))
+        # norm = torch.sqrt((x*x).sum(2))
+        norm = torch.norm(x, dim=2) + EPS
         norm_bn = self.bn(norm)
         norm = norm.unsqueeze(2)
         norm_bn = norm_bn.unsqueeze(2)


### PR DESCRIPTION
add EPS to x/norm in bn layer to avoid nan when some vi = [0,0,0]; also use norm instead of sqrt to protect the gradient

Best
Ray